### PR TITLE
fieldtrack: add testing docs

### DIFF
--- a/fieldtrack/fieldtrack.go
+++ b/fieldtrack/fieldtrack.go
@@ -8,6 +8,11 @@
 // that tracks use of struct fields.
 // This information is computed at build time for struct fields marked
 // with the `go:"track"` tag. See http://go/fieldtrack for background.
+//
+// To test run:
+//
+//     GOEXPERIMENT=fieldtrack ./make.bash
+//     go test rsc.io/tmp/fieldtrack -ldflags=-k=rsc.io/tmp/fieldtrack.tracked
 package fieldtrack
 
 import (


### PR DESCRIPTION
I have to always look up either the instructions you sent me or hope it's still in my shell history. I just spent way too long confused because somehow the -k flag was truncated in my history, so of course the test kept failing.