### PR TITLE
go2asm: update startTextRE for go1.17 assembly output

### DIFF
--- a/go2asm/README
+++ b/go2asm/README
@@ -17,17 +17,17 @@ To extract the assembly for the function math.IsNaN:
     $ go build -a -v -gcflags -S math 2>&1 | go2asm -s math.IsNaN
     #include "funcdata.h"
 
-    TEXT math·IsNaN(SB), $0-16 // /Users/rsc/go/src/math/bits.go:31
-    	NO_LOCAL_POINTERS
-    	// FUNCDATA $0, gclocals·f207267fbf96a0178e8758c6e3e0ce28(SB) (args)
-    	// FUNCDATA $1, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB) (no locals)
-    	MOVSD      f+0(FP), X0  // bits.go:36
-    	UCOMISD    X0, X0
-    	SETNE      CL
-    	SETPS      AL
-    	ORL        AX, CX
-    	MOVB       CL, is+8(FP)
-    	RET
+    TEXT math·IsNaN(SB), NOSPLIT|ABIInternal, $0-8 // /usr/local/go/src/math/bits.go:34
+        NO_LOCAL_POINTERS
+        // FUNCDATA $0, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB) (args)
+        // FUNCDATA $1, gclocals·33cdeccccebe80329f1fdbee7f5874cb(SB) (no locals)
+        FUNCDATA   $5, math·IsNaN.arginfo1(SB)
+        UCOMISD    X0, X0  // bits.go:39
+        SETNE      CL
+        SETPS      AL
+        ORL        AX, CX
+        MOVL       CX, AX
+        RET
     $
 
 Or to extract the assembly for a test program:

--- a/go2asm/main.go
+++ b/go2asm/main.go
@@ -96,7 +96,7 @@ import (
 )
 
 var (
-	startTextRE = regexp.MustCompile(`^(""\.[^ ]+) t=([^ ]+) size=([^ ]+) (?:value=[^ ]+ )?args=([^ ]+) locals=([^ ]+)$`)
+	startTextRE = regexp.MustCompile(`^(""\.[^ ]+) STEXT.* size=([^ ]+) args=([^ ]+) locals=([^ ]+) funcid=([^ ]+)$`)
 	startDataRE = regexp.MustCompile(`^([^ ]+) t=([^ ]+) size=([^ ]+)$`)
 	instRE      = regexp.MustCompile(`^\t(0x[0-9a-f]+) 0*(0|[1-9][0-9]*) \(([^\t]+:[0-9]+)\)\t([A-Z0-9].*)$`)
 )
@@ -129,7 +129,7 @@ func main() {
 	if *symFlag != "" {
 		re, err := regexp.Compile(*symFlag)
 		if err != nil {
-			log.Fatal("invalid -s regexp: %s", err)
+			log.Fatalf("invalid -s regexp: %s", err)
 		}
 		symRE = re
 	}
@@ -230,7 +230,7 @@ func asmText(text []Inst) {
 		cutBP           bool
 	)
 
-	pkgPrefix := strings.Replace(strings.Replace(pathtoprefix(pkg)+".", "/", "∕", -1), ".", "·", -1)
+	pkgPrefix := strings.ReplaceAll(strings.ReplaceAll(pathtoprefix(pkg)+".", "/", "∕"), ".", "·")
 
 	for i := range text {
 		inst := &text[i]
@@ -318,7 +318,7 @@ func asmText(text []Inst) {
 		})
 
 		// In global variable names, replace "". with assembler prefix (e.g., "math·").
-		inst.Asm = strings.Replace(inst.Asm, `"".`, pkgPrefix, -1)
+		inst.Asm = strings.ReplaceAll(inst.Asm, `"".`, pkgPrefix)
 
 		// Rewrite x+N(SP) and x+N(FP) to be in assembler form.
 		// By default the compiler prints N = the exact offset from the real SP.


### PR DESCRIPTION
Adjusted regex on ouptut from go1.17.

Fix for https://github.com/rsc/tmp/issues/8